### PR TITLE
Should get driver name instead of connection name

### DIFF
--- a/src/Http/Controllers/AdminerController.php
+++ b/src/Http/Controllers/AdminerController.php
@@ -83,7 +83,7 @@ class AdminerController extends Controller
                 if (is_null($connection)) {
                     return "server";
                 }
-                return $connection;
+                return config("database.connections.{$connection}.driver");
         }
     }
 }


### PR DESCRIPTION
For example: in cases with pgsql and where connection name (say: mydb) is different than driver name i.e. pgsql, its not working