### PR TITLE
Allow db connection for non-standard ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /node_modules
 /resources/assets/vendor
 composer.lock
+/.idea
+/.vscode
+.DS_Store

--- a/config/adminer.php
+++ b/config/adminer.php
@@ -9,7 +9,7 @@ return [
     |
     | Enable autologin to database
     |
-    | ATTENSION: Please only enable autologin with authenticated protection
+    | ATTENTION: Please only enable autologin with authenticated protection
     |
     */
     'autologin' => false,

--- a/src/Http/Controllers/AdminerController.php
+++ b/src/Http/Controllers/AdminerController.php
@@ -26,7 +26,7 @@ class AdminerController extends Controller
         $db_connection = config('database.default');
         if (! isset($_GET['db']) && config('adminer.autologin')) {
             $_POST['auth']['driver'] = $this->getDatabaseDriver(config("database.connections.{$db_connection}.driver"));
-            $_POST['auth']['server'] = config("database.connections.{$db_connection}.host");
+            $_POST['auth']['server'] = config("database.connections.{$db_connection}.host") . ':' . config("database.connections.{$db_connection}.port");
             $_POST['auth']['db'] = config("database.connections.{$db_connection}.database");
             $_POST['auth']['username'] = config("database.connections.{$db_connection}.username");
             $_POST['auth']['password'] = config("database.connections.{$db_connection}.password");


### PR DESCRIPTION
1) AdminerController.php: DB on custom port eg: 3307 not connecting currently for autologin
2) adminer.php: Spelling correction
3) .gitignore: Keeping editor configs out of vcs